### PR TITLE
Add `maxUsesPerDataKey` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import { KMSDataKeyProvider, JayZ } from "@ginger.io/jay-z"
 
 const kmsKeyId = "..." // the KMS key id or arn you want to use
 const keyProvider = new KMSDataKeyProvider(kmsKeyId, new KMS())
-const jayZ = new JayZ(keyProvider)
+const jayZ = new JayZ({ keyProvider })
 ```
 
 ### 3. Encrypt Data
@@ -74,6 +74,16 @@ If you need to specify the type, just do:
 ```TypeScript
   const decryptedItem = await jayZ.decryptItem<BankAccount, any>(encrypted))
 ```
+
+## Reusing Data Keys
+
+By default, JayZ will request a fresh data key from its `DataKeyProvider` on every encryption operation. If you'd like to trade security for speed and/or cost - you can configure this with the `maxUsesPerDataKey` setting:
+
+```TypeScript
+const jayZ = new JayZ({ keyProvider: ..., maxUsesPerDataKey: 100 })
+```
+
+This would use each data key for 100 `encrypt` operations, before requesting a fresh key from the configured `DataKeyProvider`.
 
 ## Design
 

--- a/src/main/JayZ.ts
+++ b/src/main/JayZ.ts
@@ -78,15 +78,16 @@ export class JayZ {
 
   private async getDataKey(): Promise<DataKey> {
     if (this.dataKey === undefined) {
-      this.timesDataKeyUsed = 0
+      this.timesDataKeyUsed = 1
       this.dataKey = await this.keyProvider.generateDataKey()
     } else if (this.timesDataKeyUsed >= this.maxUsesPerDataKey) {
       memzero(this.dataKey.dataKey)
-      this.timesDataKeyUsed = 0
+      this.timesDataKeyUsed = 1
       this.dataKey = await this.keyProvider.generateDataKey()
+    } else {
+      this.timesDataKeyUsed += 1
     }
 
-    this.timesDataKeyUsed += 1
     return this.dataKey
   }
 }

--- a/src/main/JayZ.ts
+++ b/src/main/JayZ.ts
@@ -1,31 +1,42 @@
 import { memzero } from "libsodium-wrappers"
-import { DataKeyProvider } from "./DataKeyProvider"
+import { DataKey, DataKeyProvider } from "./DataKeyProvider"
 import { Encryptor } from "./Encryptor"
 import { LibsodiumEncryptor } from "./LibsodiumEncryptor"
 import { EncryptedItemMetadata, EncryptedJayZItem } from "./types"
 
+export type JayZConfig = {
+  keyProvider: DataKeyProvider
+  encryptor?: Encryptor
+  maxUsesPerDataKey?: number
+}
+
 export class JayZ {
-  constructor(
-    private keyProvider: DataKeyProvider,
-    private encryptor: Encryptor = new LibsodiumEncryptor()
-  ) {}
+  private keyProvider: DataKeyProvider
+  private encryptor: Encryptor = new LibsodiumEncryptor()
+
+  private maxUsesPerDataKey: number
+  private timesDataKeyUsed: number = 0
+  private dataKey?: DataKey
+
+  constructor(config: JayZConfig) {
+    this.keyProvider = config.keyProvider
+    this.encryptor =
+      config.encryptor !== undefined
+        ? config.encryptor
+        : new LibsodiumEncryptor()
+    this.maxUsesPerDataKey = config.maxUsesPerDataKey || 1
+  }
 
   async encryptItem<T, K extends keyof T>(
     item: T,
     fieldsToEncrypt: K[]
   ): Promise<EncryptedJayZItem<T, K>> {
-    const {
-      dataKey,
-      encryptedDataKey
-    } = await this.keyProvider.generateDataKey()
-
+    const { dataKey, encryptedDataKey } = await this.getDataKey()
     const { encryptedItem, nonce } = await this.encryptor.encrypt({
       item,
       fieldsToEncrypt,
       dataKey
     })
-
-    memzero(dataKey)
 
     const __jayz__metadata: EncryptedItemMetadata<T, K> = {
       encryptedDataKey,
@@ -62,7 +73,20 @@ export class JayZ {
     })
 
     memzero(dataKey)
-
     return decryptedItem
+  }
+
+  private async getDataKey(): Promise<DataKey> {
+    if (this.dataKey === undefined) {
+      this.timesDataKeyUsed = 0
+      this.dataKey = await this.keyProvider.generateDataKey()
+    } else if (this.timesDataKeyUsed >= this.maxUsesPerDataKey) {
+      memzero(this.dataKey.dataKey)
+      this.timesDataKeyUsed = 0
+      this.dataKey = await this.keyProvider.generateDataKey()
+    }
+
+    this.timesDataKeyUsed += 1
+    return this.dataKey
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 export { DataKey, DataKeyProvider } from "./DataKeyProvider"
 export * from "./Encryptor"
-export { JayZ } from "./JayZ"
+export { JayZ, JayZConfig } from "./JayZ"
 export { KMSDataKeyProvider } from "./KMSDataKeyProvider"
 export { LibsodiumEncryptor } from "./LibsodiumEncryptor"
 export { StubDataKeyProvider } from "./StubDataKeyProvider"

--- a/src/test/Jayz.test.ts
+++ b/src/test/Jayz.test.ts
@@ -4,21 +4,24 @@ import {
   ready,
   to_base64
 } from "libsodium-wrappers"
-import { JayZ } from "../main/JayZ"
+import { DataKey, DataKeyProvider } from "../main/DataKeyProvider"
+import { JayZ, JayZConfig } from "../main/JayZ"
 import { StubDataKeyProvider } from "../main/StubDataKeyProvider"
 import { aBankAccount, BankAccount } from "./util"
 
 describe("JayZ", () => {
   beforeAll(async () => await ready)
 
+  const fieldsToEncrypt: (keyof BankAccount)[] = [
+    "accountNumber",
+    "balance",
+    "routingNumber",
+    "notes"
+  ]
+
   it("should encrypt an item", async () => {
     const { jayz, bankAccount } = setup()
-    const encryptedItem = await jayz.encryptItem(bankAccount, [
-      "accountNumber",
-      "balance",
-      "routingNumber",
-      "notes"
-    ])
+    const encryptedItem = await jayz.encryptItem(bankAccount, fieldsToEncrypt)
 
     expect(encryptedItem.pk).toEqual("account-123")
     expect(encryptedItem.sk).toEqual("Flava Flav")
@@ -32,23 +35,73 @@ describe("JayZ", () => {
 
   it("should decrypt an item", async () => {
     const { jayz, bankAccount } = setup()
-    const encryptedItem = await jayz.encryptItem(bankAccount, [
-      "accountNumber",
-      "balance",
-      "routingNumber",
-      "notes"
-    ])
-
+    const encryptedItem = await jayz.encryptItem(bankAccount, fieldsToEncrypt)
     const decryptedItem = await jayz.decryptItem(encryptedItem)
-
     expect(decryptedItem).toEqual(bankAccount)
+  })
+
+  it("should not reuse data keys by default", async () => {
+    const keyProvider = new CountingKeyProvider()
+    const { jayz, bankAccount } = setup({
+      keyProvider
+    })
+
+    expect(keyProvider.keysIssued).toEqual(0)
+    await jayz.encryptItem(bankAccount, fieldsToEncrypt)
+    expect(keyProvider.keysIssued).toEqual(1)
+
+    await jayz.encryptItem(bankAccount, fieldsToEncrypt)
+    expect(keyProvider.keysIssued).toEqual(2)
+  })
+
+  it("should reuse data keys when configured to do so", async () => {
+    const keyProvider = new CountingKeyProvider()
+    const { jayz, bankAccount } = setup({
+      keyProvider,
+      maxUsesPerDataKey: 2
+    })
+
+    const item1 = await jayz.encryptItem(bankAccount, fieldsToEncrypt)
+    expect(keyProvider.keysIssued).toEqual(1)
+
+    const item2 = await jayz.encryptItem(bankAccount, fieldsToEncrypt)
+    expect(keyProvider.keysIssued).toEqual(1)
+
+    const item3 = await jayz.encryptItem(bankAccount, fieldsToEncrypt)
+    expect(keyProvider.keysIssued).toEqual(2)
+
+    expect(await jayz.decryptItem(item1)).toEqual(bankAccount)
+    expect(await jayz.decryptItem(item2)).toEqual(bankAccount)
+    expect(await jayz.decryptItem(item3)).toEqual(bankAccount)
   })
 })
 
-function setup(): { bankAccount: BankAccount; jayz: JayZ } {
-  const key = randombytes_buf(crypto_kdf_KEYBYTES)
-  const provider = new StubDataKeyProvider(to_base64(key))
+function setup(
+  config: JayZConfig = {
+    keyProvider: new StubDataKeyProvider(
+      to_base64(randombytes_buf(crypto_kdf_KEYBYTES))
+    )
+  }
+): { bankAccount: BankAccount; jayz: JayZ } {
   const bankAccount = aBankAccount()
-  const jayz = new JayZ(provider)
+  const jayz = new JayZ(config)
   return { jayz, bankAccount }
+}
+
+class CountingKeyProvider implements DataKeyProvider {
+  public keysIssued = 0
+
+  async generateDataKey(): Promise<DataKey> {
+    await ready
+    const key = randombytes_buf(crypto_kdf_KEYBYTES)
+    this.keysIssued += 1
+    return {
+      encryptedDataKey: key.slice(0),
+      dataKey: key.slice(0)
+    }
+  }
+
+  async decryptDataKey(encryptedDataKey: Uint8Array): Promise<Uint8Array> {
+    return encryptedDataKey.slice(0)
+  }
 }


### PR DESCRIPTION
This PR adds a `maxUsesPerDataKey` to JayZ which allows callers to configure how many encryption operations to use a data key for (the default is to obtain a fresh key on every encrypt operation). 