### PR TITLE
[Jay-Z]: Ensure we handle converting JSON Buffers back to Buffer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
-    "prettier.semi": false,
-    "editor.formatOnSave": true
+  "prettier.semi": false,
+  "prettier.trailingComma": "none",
+  "editor.formatOnSave": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/jay-z",
-  "version": "0.0.1",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/jay-z",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Youve got 99 problems, but application-layer encryption aint one",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/LibsodiumEncryptor.ts
+++ b/src/main/LibsodiumEncryptor.ts
@@ -9,16 +9,22 @@ import {
   memzero,
   randombytes_buf,
   ready,
-  to_string
+  to_string,
 } from "libsodium-wrappers"
 import {
   DecryptParams,
   DecryptResult,
   Encryptor,
   EncryptParams,
-  EncryptResult
+  EncryptResult,
 } from "./Encryptor"
 import { EncryptionScheme, KeyType } from "./types"
+
+/** JSON.parse returns this object, which isn't a node Buffer */
+export type JSONBuffer = {
+  data: Array<number>
+  type: "Buffer"
+}
 
 export class LibsodiumEncryptor implements Encryptor {
   public readonly scheme = EncryptionScheme.V0_LIBSODIUM
@@ -34,7 +40,7 @@ export class LibsodiumEncryptor implements Encryptor {
 
     const encryptedFields: { [P in K]: Uint8Array } = {} as any
 
-    fieldsToEncrypt.forEach(name => {
+    fieldsToEncrypt.forEach((name) => {
       encryptedFields[name] = crypto_secretbox_easy(
         this.toBuffer(item[name]),
         nonce,
@@ -57,13 +63,23 @@ export class LibsodiumEncryptor implements Encryptor {
     const decryptionKey = this.deriveKey(dataKey, KeyType.ENCRYPTION)
 
     const decryptedItem: { [P in keyof T]: T[P] } = {
-      ...encryptedItem
+      ...encryptedItem,
     } as any
 
-    fieldsToDecrypt.forEach(name => {
-      const cipherText = encryptedItem[name]
+    fieldsToDecrypt.forEach((fieldName) => {
+      const cipherText = encryptedItem[fieldName]
       const json = crypto_secretbox_open_easy(cipherText, nonce, decryptionKey)
-      decryptedItem[name] = JSON.parse(to_string(json))
+      const fieldValue = JSON.parse(to_string(json))
+
+      // If you JSON.parse an object with a binary field that was stringified,
+      // you don't get a Buffer/Uint8Array back but rather a JSON representation of it
+      // So we special case here to convert JSON representations of buffers back to the expected type.
+      if (this.isJSONBuffer(fieldValue)) {
+        const buffer = (this.toBufferFromJSON(fieldValue) as unknown) as T[K]
+        decryptedItem[fieldName] = buffer
+      } else {
+        decryptedItem[fieldName] = fieldValue
+      }
     })
 
     memzero(decryptionKey)
@@ -80,6 +96,16 @@ export class LibsodiumEncryptor implements Encryptor {
     )
 
     return key
+  }
+
+  private toBufferFromJSON(jsonBuffer: JSONBuffer): Uint8Array {
+    return Buffer.from(jsonBuffer)
+  }
+
+  private isJSONBuffer(obj: any): obj is JSONBuffer {
+    return (
+      obj !== undefined && obj.data instanceof Array && obj.type === "Buffer"
+    )
   }
 
   private toBuffer<T extends {}>(value: T): Uint8Array {

--- a/src/main/LibsodiumEncryptor.ts
+++ b/src/main/LibsodiumEncryptor.ts
@@ -9,14 +9,14 @@ import {
   memzero,
   randombytes_buf,
   ready,
-  to_string,
+  to_string
 } from "libsodium-wrappers"
 import {
   DecryptParams,
   DecryptResult,
   Encryptor,
   EncryptParams,
-  EncryptResult,
+  EncryptResult
 } from "./Encryptor"
 import { EncryptionScheme, KeyType } from "./types"
 
@@ -40,9 +40,9 @@ export class LibsodiumEncryptor implements Encryptor {
 
     const encryptedFields: { [P in K]: Uint8Array } = {} as any
 
-    fieldsToEncrypt.forEach((name) => {
-      encryptedFields[name] = crypto_secretbox_easy(
-        this.toBuffer(item[name]),
+    fieldsToEncrypt.forEach((fieldName) => {
+      encryptedFields[fieldName] = crypto_secretbox_easy(
+        this.toBuffer(item[fieldName]),
         nonce,
         encryptionKey
       )
@@ -63,7 +63,7 @@ export class LibsodiumEncryptor implements Encryptor {
     const decryptionKey = this.deriveKey(dataKey, KeyType.ENCRYPTION)
 
     const decryptedItem: { [P in keyof T]: T[P] } = {
-      ...encryptedItem,
+      ...encryptedItem
     } as any
 
     fieldsToDecrypt.forEach((fieldName) => {

--- a/src/test/LibsodiumEncryptor.test.ts
+++ b/src/test/LibsodiumEncryptor.test.ts
@@ -3,7 +3,7 @@ import {
   crypto_kdf_derive_from_key,
   crypto_secretbox_easy,
   crypto_secretbox_KEYBYTES,
-  from_string,
+  from_string
 } from "libsodium-wrappers"
 import { LibsodiumEncryptor } from "../main/LibsodiumEncryptor"
 import { StubDataKeyProvider } from "../main/StubDataKeyProvider"
@@ -17,7 +17,7 @@ describe("LibsodiumEncryptor", () => {
     "accountNumber",
     "balance",
     "routingNumber",
-    "notes",
+    "notes"
   ]
 
   it("should encrypt an item", async () => {
@@ -27,7 +27,7 @@ describe("LibsodiumEncryptor", () => {
     const { encryptedItem, nonce } = await encryptor.encrypt({
       item: account,
       fieldsToEncrypt,
-      dataKey,
+      dataKey
     })
 
     expect(encryptedItem.pk).toEqual("account-123")
@@ -58,39 +58,39 @@ describe("LibsodiumEncryptor", () => {
     const { encryptedItem, nonce } = await encryptor.encrypt({
       item: account,
       fieldsToEncrypt,
-      dataKey,
+      dataKey
     })
 
     const { decryptedItem } = await encryptor.decrypt({
       encryptedItem,
       nonce,
       dataKey,
-      fieldsToDecrypt: fieldsToEncrypt,
+      fieldsToDecrypt: fieldsToEncrypt
     })
 
     expect(decryptedItem).toEqual(account)
   })
 
-  it("should handle binary fields", async () => {
+  it("should encrypt and decrypt binary fields", async () => {
     const dataKeyProvider = await StubDataKeyProvider.forLibsodium()
     const { dataKey } = await dataKeyProvider.generateDataKey()
 
     const binaryItem = {
       name: "hello world",
-      binaryData: Buffer.from("hello world", "utf-8"),
+      binaryData: Buffer.from("hello world", "utf-8")
     }
 
     const { encryptedItem, nonce } = await encryptor.encrypt({
       item: binaryItem,
       fieldsToEncrypt: ["name", "binaryData"],
-      dataKey,
+      dataKey
     })
 
     const { decryptedItem } = await encryptor.decrypt({
       encryptedItem,
       nonce,
       dataKey,
-      fieldsToDecrypt: ["name", "binaryData"],
+      fieldsToDecrypt: ["name", "binaryData"]
     })
 
     expect(decryptedItem).toEqual(binaryItem)

--- a/src/test/LibsodiumEncryptor.test.ts
+++ b/src/test/LibsodiumEncryptor.test.ts
@@ -3,7 +3,7 @@ import {
   crypto_kdf_derive_from_key,
   crypto_secretbox_easy,
   crypto_secretbox_KEYBYTES,
-  from_string
+  from_string,
 } from "libsodium-wrappers"
 import { LibsodiumEncryptor } from "../main/LibsodiumEncryptor"
 import { StubDataKeyProvider } from "../main/StubDataKeyProvider"
@@ -17,7 +17,7 @@ describe("LibsodiumEncryptor", () => {
     "accountNumber",
     "balance",
     "routingNumber",
-    "notes"
+    "notes",
   ]
 
   it("should encrypt an item", async () => {
@@ -27,7 +27,7 @@ describe("LibsodiumEncryptor", () => {
     const { encryptedItem, nonce } = await encryptor.encrypt({
       item: account,
       fieldsToEncrypt,
-      dataKey
+      dataKey,
     })
 
     expect(encryptedItem.pk).toEqual("account-123")
@@ -40,7 +40,7 @@ describe("LibsodiumEncryptor", () => {
       dataKey
     )
 
-    fieldsToEncrypt.forEach(fieldName => {
+    fieldsToEncrypt.forEach((fieldName) => {
       const expectedValue = crypto_secretbox_easy(
         from_string(stringify(account[fieldName])),
         nonce,
@@ -58,16 +58,41 @@ describe("LibsodiumEncryptor", () => {
     const { encryptedItem, nonce } = await encryptor.encrypt({
       item: account,
       fieldsToEncrypt,
-      dataKey
+      dataKey,
     })
 
     const { decryptedItem } = await encryptor.decrypt({
       encryptedItem,
       nonce,
       dataKey,
-      fieldsToDecrypt: fieldsToEncrypt
+      fieldsToDecrypt: fieldsToEncrypt,
     })
 
     expect(decryptedItem).toEqual(account)
+  })
+
+  it("should handle binary fields", async () => {
+    const dataKeyProvider = await StubDataKeyProvider.forLibsodium()
+    const { dataKey } = await dataKeyProvider.generateDataKey()
+
+    const binaryItem = {
+      name: "hello world",
+      binaryData: Buffer.from("hello world", "utf-8"),
+    }
+
+    const { encryptedItem, nonce } = await encryptor.encrypt({
+      item: binaryItem,
+      fieldsToEncrypt: ["name", "binaryData"],
+      dataKey,
+    })
+
+    const { decryptedItem } = await encryptor.decrypt({
+      encryptedItem,
+      nonce,
+      dataKey,
+      fieldsToDecrypt: ["name", "binaryData"],
+    })
+
+    expect(decryptedItem).toEqual(binaryItem)
   })
 })


### PR DESCRIPTION
This PR makes Jay-Z  properly handle objects with fields that are Buffers.  

Previously Jay-Z would encrypt/decrypt the binary data just fine. But the type you'd get back after decrypting would be a JSON representation of the buffer vs the original input buffer. 