### PR TITLE
[Jay-Z]: API tweaks for better safety and fix a concurrency bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const bankAccount: BankAccount = {
   routingNumber: "rn-123"
 }
 
-const encryptedItem = await jayZ.encryptItem(bankAccount, ["accountNumber", "routingNumber"])
+const encryptedItem = await jayZ.encryptItems({ item: bankAccount, fieldsToEncrypt: ["accountNumber", "routingNumber"] })
 ```
 
 Here you specify _only_ the fields you want encrypted. JayZ doesn't suffer foolish mistakes - so this API is completely type-safe.
@@ -64,7 +64,7 @@ If you have the encrypted item in scope with the right types,
 you can just do:
 
 ```TypeScript
-  const decryptedItem = await jayZ.decryptItem(encrypted))
+  const [decryptedItem] = await jayZ.decryptItems([encryptedItem]))
 ```
 
 And the correct type, `BankAccount` in this example will be automatically inferred.
@@ -72,7 +72,7 @@ And the correct type, `BankAccount` in this example will be automatically inferr
 If you need to specify the type, just do:
 
 ```TypeScript
-  const decryptedItem = await jayZ.decryptItem<BankAccount, any>(encrypted))
+  const [decryptedItem] = await jayZ.decryptItems<BankAccount, any>([encryptedItem]))
 ```
 
 ## Reusing Data Keys

--- a/src/main/Encryptor.ts
+++ b/src/main/Encryptor.ts
@@ -27,9 +27,7 @@ export interface Encryptor {
 
   encrypt<T, K extends keyof T>(
     params: EncryptParams<T, K>
-  ): Promise<EncryptResult<T, K>>
+  ): EncryptResult<T, K>
 
-  decrypt<T, K extends keyof T>(
-    params: DecryptParams<T, K>
-  ): Promise<DecryptResult<T>>
+  decrypt<T, K extends keyof T>(params: DecryptParams<T, K>): DecryptResult<T>
 }

--- a/src/main/JayZ.ts
+++ b/src/main/JayZ.ts
@@ -10,13 +10,19 @@ export type JayZConfig = {
   maxUsesPerDataKey?: number
 }
 
+export type EncryptItemRequest<T, K extends keyof T> = {
+  item: T
+  fieldsToEncrypt: K[]
+}
+
 export class JayZ {
   private keyProvider: DataKeyProvider
   private encryptor: Encryptor = new LibsodiumEncryptor()
 
   private maxUsesPerDataKey: number
-  private timesDataKeyUsed: number = 0
-  private dataKey?: DataKey
+
+  private currentDataKey?: Promise<DataKey>
+  private currentDataKeyUsesRemaining: number
 
   constructor(config: JayZConfig) {
     this.keyProvider = config.keyProvider
@@ -25,69 +31,99 @@ export class JayZ {
         ? config.encryptor
         : new LibsodiumEncryptor()
     this.maxUsesPerDataKey = config.maxUsesPerDataKey || 1
+    this.currentDataKeyUsesRemaining = this.maxUsesPerDataKey
   }
 
-  async encryptItem<T, K extends keyof T>(
-    item: T,
-    fieldsToEncrypt: K[]
-  ): Promise<EncryptedJayZItem<T, K>> {
-    const { dataKey, encryptedDataKey } = await this.getDataKey()
-    const { encryptedItem, nonce } = await this.encryptor.encrypt({
-      item,
-      fieldsToEncrypt,
-      dataKey
+  async encryptItems<T, K extends keyof T>(
+    itemsToEncrypt: EncryptItemRequest<T, K>[]
+  ): Promise<EncryptedJayZItem<T, K>[]> {
+    if (itemsToEncrypt.length === 0) {
+      return []
+    }
+
+    const itemsWithKey = await this.zipItemsWithDataKey(itemsToEncrypt)
+
+    const itemPromises = itemsWithKey.map(async ({ itemToEncrypt, key }) => {
+      const { item, fieldsToEncrypt } = itemToEncrypt
+      const { dataKey, encryptedDataKey } = key
+      const { encryptedItem, nonce } = await this.encryptor.encrypt({
+        item,
+        fieldsToEncrypt,
+        dataKey
+      })
+
+      const __jayz__metadata: EncryptedItemMetadata<T, K> = {
+        encryptedDataKey,
+        nonce,
+        scheme: this.encryptor.scheme,
+        encryptedFieldNames: fieldsToEncrypt
+      }
+
+      return {
+        ...encryptedItem,
+        __jayz__metadata
+      }
     })
 
-    const __jayz__metadata: EncryptedItemMetadata<T, K> = {
-      encryptedDataKey,
-      nonce,
-      scheme: this.encryptor.scheme,
-      encryptedFieldNames: fieldsToEncrypt
-    }
-
-    return {
-      ...encryptedItem,
-      __jayz__metadata
-    }
+    return Promise.all(itemPromises)
   }
 
-  async decryptItem<T, K extends keyof T>(
-    encryptedJayZItem: EncryptedJayZItem<T, K>
-  ): Promise<T> {
-    const {
-      nonce,
-      encryptedDataKey,
-      encryptedFieldNames
-    } = encryptedJayZItem.__jayz__metadata
+  async decryptItems<T, K extends keyof T>(
+    itemsToDecrypt: EncryptedJayZItem<T, K>[]
+  ): Promise<T[]> {
+    if (itemsToDecrypt.length === 0) {
+      return []
+    }
 
-    const encryptedItem = { ...encryptedJayZItem }
-    delete (encryptedItem as any).__jayz__metadata
+    const itemPromises = itemsToDecrypt.map(async (item) => {
+      const {
+        nonce,
+        encryptedDataKey,
+        encryptedFieldNames
+      } = item.__jayz__metadata
 
-    const dataKey = await this.keyProvider.decryptDataKey(encryptedDataKey)
+      const encryptedItem = { ...item }
+      delete (encryptedItem as any).__jayz__metadata
 
-    const { decryptedItem } = await this.encryptor.decrypt<T, K>({
-      encryptedItem,
-      fieldsToDecrypt: encryptedFieldNames,
-      dataKey,
-      nonce
+      const dataKey = await this.keyProvider.decryptDataKey(encryptedDataKey)
+
+      const { decryptedItem } = await this.encryptor.decrypt<T, K>({
+        encryptedItem,
+        fieldsToDecrypt: encryptedFieldNames,
+        dataKey,
+        nonce
+      })
+
+      memzero(dataKey)
+      return decryptedItem
     })
 
-    memzero(dataKey)
-    return decryptedItem
+    return Promise.all(itemPromises)
   }
 
-  private async getDataKey(): Promise<DataKey> {
-    if (this.dataKey === undefined) {
-      this.timesDataKeyUsed = 1
-      this.dataKey = await this.keyProvider.generateDataKey()
-    } else if (this.timesDataKeyUsed >= this.maxUsesPerDataKey) {
-      memzero(this.dataKey.dataKey)
-      this.timesDataKeyUsed = 1
-      this.dataKey = await this.keyProvider.generateDataKey()
-    } else {
-      this.timesDataKeyUsed += 1
-    }
+  private zipItemsWithDataKey<T, K extends keyof T>(
+    items: EncryptItemRequest<T, K>[]
+  ): Promise<{ itemToEncrypt: EncryptItemRequest<T, K>; key: DataKey }[]> {
+    const itemsWithDataKeys = items.map((itemToEncrypt) => {
+      if (
+        this.currentDataKey !== undefined &&
+        this.currentDataKeyUsesRemaining > 0
+      ) {
+        this.currentDataKeyUsesRemaining -= 1
+        return { itemToEncrypt, key: this.currentDataKey }
+      } else {
+        this.currentDataKey = this.keyProvider.generateDataKey()
+        this.currentDataKeyUsesRemaining = this.maxUsesPerDataKey - 1
+        return { itemToEncrypt, key: this.currentDataKey }
+      }
+    })
 
-    return this.dataKey
+    const itemWithDataKeyPromises = itemsWithDataKeys.map(
+      async ({ itemToEncrypt, key }) => {
+        return { itemToEncrypt, key: await key }
+      }
+    )
+
+    return Promise.all(itemWithDataKeyPromises)
   }
 }

--- a/src/main/LibsodiumEncryptor.ts
+++ b/src/main/LibsodiumEncryptor.ts
@@ -29,11 +29,9 @@ export type JSONBuffer = {
 export class LibsodiumEncryptor implements Encryptor {
   public readonly scheme = EncryptionScheme.V0_LIBSODIUM
 
-  async encrypt<T, K extends keyof T>(
+  encrypt<T, K extends keyof T>(
     params: EncryptParams<T, K>
-  ): Promise<EncryptResult<T, K>> {
-    await ready
-
+  ): EncryptResult<T, K> {
     const { item, fieldsToEncrypt, dataKey } = params
     const nonce = randombytes_buf(crypto_secretbox_NONCEBYTES)
     const encryptionKey = this.deriveKey(dataKey, KeyType.ENCRYPTION)
@@ -54,11 +52,7 @@ export class LibsodiumEncryptor implements Encryptor {
     return { encryptedItem, nonce }
   }
 
-  async decrypt<T, K extends keyof T>(
-    params: DecryptParams<T, K>
-  ): Promise<DecryptResult<T>> {
-    await ready
-
+  decrypt<T, K extends keyof T>(params: DecryptParams<T, K>): DecryptResult<T> {
     const { encryptedItem, fieldsToDecrypt, nonce, dataKey } = params
     const decryptionKey = this.deriveKey(dataKey, KeyType.ENCRYPTION)
 


### PR DESCRIPTION
**What's in this PR?**
This PR makes some tweaks to Jay-Z to make its API safer and fixes a concurrency bug related to `maxUsesPerDataKey`. Specifically: 

**Impetus**
1. Prior to this PR,  we would zero out generated encryption keys (data keys) when the current key "expired" (max # of uses hit) and we went to go generate a new key. But, for batch workflows where the caller might hold N encrypted items in memory, this is problematic as results in zero-ing out those keys before they get persisted. This of course breaks decryption.

2. Prior to this PR we had a block of code like: 

```TypeScript
if (this.dataKey === undefined) {
      this.timesDataKeyUsed = 1
      this.dataKey = await this.keyProvider.generateDataKey()
    } 
```
^ The problem with that is if `this.dataKey` is `undefined` and you trigger it N times in the same event loop tick, you end up generating N data keys regardless of whether or not you tried to tune `maxUsesPerDataKey`. 

**Solution**

This PR should fix both problems. And tweaks Jay-Z's API so that it now uses batch methods: `encryptItems` and `decryptItems`. Using batch-style methods gives us a bit more visibility and control into planning/optimizing for encrypting sets of items. 