### PR TITLE
[Jay-Z]: Generate fewer promises when batch encrypting data

### DIFF
--- a/src/main/Encryptor.ts
+++ b/src/main/Encryptor.ts
@@ -27,9 +27,7 @@ export interface Encryptor {
 
   encrypt<T, K extends keyof T>(
     params: EncryptParams<T, K>
-  ): Promise<EncryptResult<T, K>>
+  ): EncryptResult<T, K>
 
-  decrypt<T, K extends keyof T>(
-    params: DecryptParams<T, K>
-  ): Promise<DecryptResult<T>>
+  decrypt<T, K extends keyof T>(params: DecryptParams<T, K>): DecryptResult<T>
 }

--- a/src/main/LibsodiumEncryptor.ts
+++ b/src/main/LibsodiumEncryptor.ts
@@ -29,11 +29,9 @@ export type JSONBuffer = {
 export class LibsodiumEncryptor implements Encryptor {
   public readonly scheme = EncryptionScheme.V0_LIBSODIUM
 
-  async encrypt<T, K extends keyof T>(
+  encrypt<T, K extends keyof T>(
     params: EncryptParams<T, K>
-  ): Promise<EncryptResult<T, K>> {
-    await ready
-
+  ): EncryptResult<T, K> {
     const { item, fieldsToEncrypt, dataKey } = params
     const nonce = randombytes_buf(crypto_secretbox_NONCEBYTES)
     const encryptionKey = this.deriveKey(dataKey, KeyType.ENCRYPTION)
@@ -54,11 +52,7 @@ export class LibsodiumEncryptor implements Encryptor {
     return { encryptedItem, nonce }
   }
 
-  async decrypt<T, K extends keyof T>(
-    params: DecryptParams<T, K>
-  ): Promise<DecryptResult<T>> {
-    await ready
-
+  decrypt<T, K extends keyof T>(params: DecryptParams<T, K>): DecryptResult<T> {
     const { encryptedItem, fieldsToDecrypt, nonce, dataKey } = params
     const decryptionKey = this.deriveKey(dataKey, KeyType.ENCRYPTION)
 


### PR DESCRIPTION
This PR builds off of https://github.com/ginger-io/jay-z/pull/8 and adds an optimization that reduces the number of `Promise` objects we generate when encrypting items. 

Previously, our `Encryptor` interface returned a Promise, which forced every encrypted item to also be a Promise. Here we move that to be sync instead of async. 