### PR TITLE
[JayZ]: Add methods for encrypting/decrypting a single item

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ import { KMSDataKeyProvider, JayZ } from "@ginger.io/jay-z"
 const kmsKeyId = "..." // the KMS key id or arn you want to use
 const keyProvider = new KMSDataKeyProvider(kmsKeyId, new KMS())
 const jayZ = new JayZ({ keyProvider })
+await jayZ.ready // wait for JayZ to be ready for encryption operations
 ```
 
 ### 3. Encrypt Data
@@ -51,7 +52,7 @@ const bankAccount: BankAccount = {
   routingNumber: "rn-123"
 }
 
-const encryptedItem = await jayZ.encryptItems({ item: bankAccount, fieldsToEncrypt: ["accountNumber", "routingNumber"] })
+const encryptedItem = await jayZ.encryptItem({ item: bankAccount, fieldsToEncrypt: ["accountNumber", "routingNumber"] })
 ```
 
 Here you specify _only_ the fields you want encrypted. JayZ doesn't suffer foolish mistakes - so this API is completely type-safe.
@@ -64,7 +65,7 @@ If you have the encrypted item in scope with the right types,
 you can just do:
 
 ```TypeScript
-  const [decryptedItem] = await jayZ.decryptItems([encryptedItem]))
+  const decryptedItem = await jayZ.decryptItem(encryptedItem))
 ```
 
 And the correct type, `BankAccount` in this example will be automatically inferred.
@@ -72,7 +73,7 @@ And the correct type, `BankAccount` in this example will be automatically inferr
 If you need to specify the type, just do:
 
 ```TypeScript
-  const [decryptedItem] = await jayZ.decryptItems<BankAccount, any>([encryptedItem]))
+  const decryptedItem = await jayZ.decryptItem<BankAccount, any>(encryptedItem))
 ```
 
 ## Reusing Data Keys

--- a/src/test/Jayz.test.ts
+++ b/src/test/Jayz.test.ts
@@ -1,12 +1,12 @@
 import {
   crypto_kdf_KEYBYTES,
   randombytes_buf,
-  ready,
   to_base64,
+  ready
 } from "libsodium-wrappers"
 import { DataKey, DataKeyProvider } from "../main/DataKeyProvider"
-import { JayZ, JayZConfig } from "../main/JayZ"
 import { FixedDataKeyProvider } from "../main/FixedDataKeyProvider"
+import { JayZ, JayZConfig } from "../main/JayZ"
 import { aBankAccount, BankAccount } from "./util"
 
 describe("JayZ", () => {
@@ -16,14 +16,15 @@ describe("JayZ", () => {
     "accountNumber",
     "balance",
     "routingNumber",
-    "notes",
+    "notes"
   ]
 
   it("should encrypt an item", async () => {
     const { jayz, bankAccount } = setup()
-    const [encryptedItem] = await jayz.encryptItems([
-      { item: bankAccount, fieldsToEncrypt },
-    ])
+    const encryptedItem = await jayz.encryptItem({
+      item: bankAccount,
+      fieldsToEncrypt
+    })
 
     expect(encryptedItem.pk).toEqual("account-123")
     expect(encryptedItem.sk).toEqual("Flava Flav")
@@ -31,31 +32,32 @@ describe("JayZ", () => {
     expect(encryptedItem.routingNumber).not.toEqual("456")
     expect(encryptedItem.balance).not.toEqual(100)
     expect(encryptedItem.notes).not.toEqual({
-      previousBalances: [0, 50],
+      previousBalances: [0, 50]
     })
   })
 
   it("should decrypt an item", async () => {
     const { jayz, bankAccount } = setup()
 
-    const [encryptedItem] = await jayz.encryptItems([
-      { item: bankAccount, fieldsToEncrypt },
-    ])
+    const encryptedItem = await jayz.encryptItem({
+      item: bankAccount,
+      fieldsToEncrypt
+    })
 
-    const [decryptedItem] = await jayz.decryptItems([encryptedItem])
+    const decryptedItem = await jayz.decryptItem(encryptedItem)
     expect(decryptedItem).toEqual(bankAccount)
   })
 
   it("should not reuse data keys by default when encryptItems invoked with multiple items", async () => {
     const keyProvider = new CountingKeyProvider()
     const { jayz, bankAccount } = setup({
-      keyProvider,
+      keyProvider
     })
 
     expect(keyProvider.keysIssued).toEqual(0)
     await jayz.encryptItems([
       { item: bankAccount, fieldsToEncrypt },
-      { item: bankAccount, fieldsToEncrypt },
+      { item: bankAccount, fieldsToEncrypt }
     ])
 
     expect(keyProvider.keysIssued).toEqual(2)
@@ -64,7 +66,7 @@ describe("JayZ", () => {
   it("should not reuse data keys by default when encryptItems invoked multiple times", async () => {
     const keyProvider = new CountingKeyProvider()
     const { jayz, bankAccount } = setup({
-      keyProvider,
+      keyProvider
     })
 
     expect(keyProvider.keysIssued).toEqual(0)
@@ -79,19 +81,19 @@ describe("JayZ", () => {
     const keyProvider = new CountingKeyProvider()
     const { jayz, bankAccount } = setup({
       keyProvider,
-      maxUsesPerDataKey: 2,
+      maxUsesPerDataKey: 2
     })
 
     const [item1, item2, item3] = await jayz.encryptItems([
       { item: bankAccount, fieldsToEncrypt },
       { item: bankAccount, fieldsToEncrypt },
-      { item: bankAccount, fieldsToEncrypt },
+      { item: bankAccount, fieldsToEncrypt }
     ])
 
     const [
       decryptedItem1,
       decryptedItem2,
-      decryptedItem3,
+      decryptedItem3
     ] = await jayz.decryptItems([item1, item2, item3])
 
     expect(decryptedItem1).toEqual(bankAccount)
@@ -111,12 +113,12 @@ describe("JayZ", () => {
     const keyProvider = new CountingKeyProvider()
     const { jayz, bankAccount } = setup({
       keyProvider,
-      maxUsesPerDataKey: 2,
+      maxUsesPerDataKey: 2
     })
 
     const encryptAndDecrypt = async () => {
       const [encryptedItem] = await jayz.encryptItems([
-        { item: bankAccount, fieldsToEncrypt },
+        { item: bankAccount, fieldsToEncrypt }
       ])
 
       const [decryptedItem] = await jayz.decryptItems([encryptedItem])
@@ -138,7 +140,7 @@ function setup(
   config: JayZConfig = {
     keyProvider: new FixedDataKeyProvider(
       to_base64(randombytes_buf(crypto_kdf_KEYBYTES))
-    ),
+    )
   }
 ): { bankAccount: BankAccount; jayz: JayZ } {
   const bankAccount = aBankAccount()
@@ -155,7 +157,7 @@ class CountingKeyProvider implements DataKeyProvider {
     this.keysIssued += 1
     return {
       encryptedDataKey: key,
-      dataKey: key,
+      dataKey: key
     }
   }
 


### PR DESCRIPTION
This  PR adds two new methods: `encryptItem` and `decryptItem`, previously we only offered "bulk" methods -- `encryptItems` and `decryptItems`. 

Offering singular methods gives the caller more control of failure scenarios when attempting to encrypt/decrypt. 

A small optimization is also included in this PR, where we were triggering extra event loop ticks by awaiting on the `ready` promise provided by `libsodium-wrappers`. Now we provide a `.ready` property on the JayZ class for callers to `await`. 