### PR TITLE
fix: Reuse of nonce in LibsodiumEncryptor

### DIFF
--- a/src/main/encryptors/Encryptor.ts
+++ b/src/main/encryptors/Encryptor.ts
@@ -21,18 +21,39 @@ export interface DecryptResult<T> {
   decryptedItem: T
 }
 
-export type EncryptedJayZItem<T, U extends keyof T> = ItemWithEncryptedFields<T, U> & {
-  __jayz__metadata: EncryptedItemMetadata<T, U>
+export type EncryptedJayZItem<T, U extends keyof T> = LegacyEncryptedJayZItem<T, U> | EncryptedJayZItemV1<T, U>
+
+export type LegacyEncryptedJayZItem<T, U extends keyof T> = ItemWithEncryptedFields<T, U> & {
+  __jayz__metadata: {
+    version: string
+    keyId?: string
+    nonce: Uint8Array
+    encryptedDataKey: Uint8Array
+    encryptedFieldNames: U[]
+  }
+}
+
+export type EncryptedJayZItemV1<T, U extends keyof T> = Omit<T, U> & {
+  __jayz__metadata: {
+    metadataVersion: MetadataVersion.V1
+    encryptorId: string
+    keyId?: string
+    nonce: Uint8Array
+    encryptedDataKey: Uint8Array
+    encryptedFields: Uint8Array
+  }
+}
+
+export function isLegacyJayZItem<T, U extends keyof T>(
+  item: EncryptedJayZItem<T, U>
+): item is LegacyEncryptedJayZItem<T, U> {
+  return (item as any).__jayz__metadata.encryptedFieldNames !== undefined
+}
+
+export enum MetadataVersion {
+  V1
 }
 
 export type ItemWithEncryptedFields<T, U extends keyof T> = Omit<T, U> & {
   [K in U]: Uint8Array
-}
-
-export interface EncryptedItemMetadata<T, U extends keyof T> {
-  version: string
-  keyId?: string
-  nonce: Uint8Array
-  encryptedDataKey: Uint8Array
-  encryptedFieldNames: U[]
 }

--- a/src/main/encryptors/serialization.ts
+++ b/src/main/encryptors/serialization.ts
@@ -20,7 +20,7 @@ export function deserialize(bytes: Uint8Array): any {
 function convertJsonBuffers(obj: any): any {
   if (isJsonBuffer(obj)) {
     return Buffer.from(obj)
-  } else if (typeof obj === "object") {
+  } else if (obj !== null && typeof obj === "object") {
     Object.keys(obj).forEach((key) => {
       obj[key] = convertJsonBuffers(obj[key])
     })
@@ -35,5 +35,5 @@ interface JsonBuffer {
 }
 
 function isJsonBuffer(obj: any): obj is JsonBuffer {
-  return obj !== undefined && obj.data instanceof Array && obj.type === "Buffer"
+  return obj !== undefined && obj !== null && obj.data instanceof Array && obj.type === "Buffer"
 }

--- a/src/test/Jayz.test.ts
+++ b/src/test/Jayz.test.ts
@@ -14,17 +14,15 @@ describe("JayZ", () => {
     const { jayz, bankAccount } = setup()
     const encryptedItem = await jayz.encryptItem({
       item: bankAccount,
-      fieldsToEncrypt
+      fieldsToEncrypt: ["accountNumber", "balance", "routingNumber", "notes"]
     })
 
     expect(encryptedItem.pk).toEqual("account-123")
     expect(encryptedItem.sk).toEqual("Flava Flav")
-    expect(encryptedItem.accountNumber).not.toEqual("123")
-    expect(encryptedItem.routingNumber).not.toEqual("456")
-    expect(encryptedItem.balance).not.toEqual(100)
-    expect(encryptedItem.notes).not.toEqual({
-      previousBalances: [0, 50]
-    })
+    expect(encryptedItem).not.toHaveProperty("accountNumber")
+    expect(encryptedItem).not.toHaveProperty("routingNumber")
+    expect(encryptedItem).not.toHaveProperty("balance")
+    expect(encryptedItem).not.toHaveProperty("notes")
   })
 
   it("should decrypt an item", async () => {

--- a/src/test/encryptors/LibsodiumEncryptor.test.ts
+++ b/src/test/encryptors/LibsodiumEncryptor.test.ts
@@ -1,7 +1,8 @@
 import stringify from "fast-json-stable-stringify"
-import { crypto_secretbox_easy, from_string } from "libsodium-wrappers"
-import { LibsodiumEncryptor } from "../../main/encryptors"
-import { FixedKeyProvider } from "../../main/key-providers"
+import { crypto_secretbox_easy, crypto_secretbox_NONCEBYTES, from_string, randombytes_buf } from "libsodium-wrappers"
+import { EncryptProps, EncryptResult, ItemWithEncryptedFields, LibsodiumEncryptor } from "../../main/encryptors"
+import { serialize } from "../../main/encryptors/serialization"
+import { FixedKeyProvider, KeyProvider } from "../../main/key-providers"
 import { aBankAccount, BankAccount } from "../util"
 
 describe("LibsodiumEncryptor", () => {
@@ -13,25 +14,36 @@ describe("LibsodiumEncryptor", () => {
     const { plaintextKey } = await keyProvider.generateDataKey()
     const { encryptedItem } = await encryptor.encrypt({
       item: account,
-      fieldsToEncrypt
+      fieldsToEncrypt: ["accountNumber", "balance", "routingNumber", "notes"]
     })
 
     expect(encryptedItem.pk).toEqual("account-123")
     expect(encryptedItem.sk).toEqual("Flava Flav")
 
+    const fields = {} as any
     fieldsToEncrypt.forEach((fieldName) => {
-      const expectedValue = crypto_secretbox_easy(
-        from_string(stringify(account[fieldName])),
-        encryptedItem.__jayz__metadata.nonce,
-        plaintextKey
-      )
-      expect(encryptedItem[fieldName]).toEqual(expectedValue)
+      fields[fieldName] = account[fieldName]
     })
+
+    const encryptedFields = crypto_secretbox_easy(
+      from_string(stringify(fields)),
+      encryptedItem.__jayz__metadata.nonce,
+      plaintextKey
+    )
+
+    expect((encryptedItem.__jayz__metadata as any).encryptedFields).toEqual(encryptedFields)
   })
 
   it("should decrypt an item", async () => {
     const { encryptor } = await setup()
     const { encryptedItem } = await encryptor.encrypt({ item: account, fieldsToEncrypt })
+    const { decryptedItem } = await encryptor.decrypt({ item: encryptedItem })
+    expect(decryptedItem).toEqual(account)
+  })
+
+  it("should decrypt a legacy item", async () => {
+    const { encryptor, keyProvider } = await setup()
+    const { encryptedItem } = await legacyEncrypt(keyProvider, { item: account, fieldsToEncrypt })
     const { decryptedItem } = await encryptor.decrypt({ item: encryptedItem })
     expect(decryptedItem).toEqual(account)
   })
@@ -84,4 +96,43 @@ async function setup(): Promise<{ keyProvider: FixedKeyProvider; encryptor: Libs
   const keyProvider = await FixedKeyProvider.forLibsodium()
   const encryptor = new LibsodiumEncryptor({ keyProvider })
   return { encryptor, keyProvider }
+}
+
+/** This is a copy/pasted "legacy" version of LibsodiumEncryptor's encrypt function, which had
+ *  a bug that reused nonces across multiple encrypt operations.
+ *
+ *  It is preserved here for testing to ensure we can decrypt items encrypted with this format
+ *  */
+async function legacyEncrypt<T, U extends keyof T>(
+  keyProvider: KeyProvider,
+  props: EncryptProps<T, U>
+): Promise<EncryptResult<T, U>> {
+  const { item, fieldsToEncrypt } = props
+  const key = await keyProvider.generateDataKey()
+  const nonce = randombytes_buf(crypto_secretbox_NONCEBYTES)
+
+  const encryptedFields: {
+    [K in U]: Uint8Array
+  } = {} as ItemWithEncryptedFields<T, U>
+
+  fieldsToEncrypt.forEach((fieldName) => {
+    const fieldValue = item[fieldName]
+    if (fieldValue !== undefined && fieldValue !== null) {
+      encryptedFields[fieldName] = crypto_secretbox_easy(serialize(fieldValue), nonce, key.plaintextKey)
+    }
+  })
+
+  const encryptedItem = {
+    ...item,
+    ...encryptedFields,
+    __jayz__metadata: {
+      encryptedDataKey: key.encryptedKey,
+      keyId: key.metadata?.keyId,
+      nonce,
+      version: "v0",
+      encryptedFieldNames: fieldsToEncrypt
+    }
+  }
+
+  return { encryptedItem }
 }


### PR DESCRIPTION
This PR fixes a bug where `LibsodiumEncryptor` was reusing a nonce across multiple encryption operations. 

More specifically before this PR, if you told it to encrypt fields A, B and C on a JSON document -- it'd encrypt each field separately, and reuse the same key (fine) and nonce (not fine) for each field. 

This PR changes that behavior so we don't reuse the nonce. And we make an additional improvement where we'll now encrypt all requested fields in a single operation  + don't expose the names of the encrypted fields in plaintext. 