### PR TITLE
Use GitHub Action for test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout
+        uses: actions/checkout@v3
       - name: Setup Node.js environment
-        uses: actions/setup-node
+        uses: actions/setup-node@v3
         with:
           node-version: current
           cache: yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+---
+name: Test
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout
+      - name: Setup Node.js environment
+        uses: actions/setup-node
+        with:
+          node-version: current
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
+      - name: Run tests
+        run: yarn test


### PR DESCRIPTION
https://headspace.atlassian.net/browse/PROD-80

We currently only have eight [projects](https://app.codeship.com/projects) on CodeShip. This repo appears to only use CodeShip to run unit tests, which makes the most sense to do as a GitHub Action, IMO.

I'm keeping the CodeShip integration for now until we can verify the GitHub Action works as intended.

See https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs (although I'm attempting to use the latest version of Node and the dependent GitHub actions)