### PR TITLE
Remove CodeShip integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM node:12.18.3-alpine
-
-WORKDIR /usr/app
-COPY . ./
-RUN apk add --update \
-    yarn \
-    nodejs \
-    npm

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,7 +1,0 @@
-jay_z:
-  build: .
-  cached: true
-
-  #Volume needed for a step to use another step's artifact
-  volumes:
-    - .:/usr/app

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,7 +1,0 @@
-- name: build
-  service: jay_z
-  command: /bin/sh -c "yarn install && yarn build"
-
-- name: test
-  service: jay_z
-  command: /bin/sh -c "yarn test"


### PR DESCRIPTION
This reverts commit 4b5a54cc0b34bca835ae9d194409f9146ba7c816.

As an add'l benefit, note that the GitHub Action ran in 49s, but the CodeShip run is still pending after 15mins:

<img width="914" alt="image" src="https://user-images.githubusercontent.com/697964/236292052-df2be4e1-4611-4a46-ad44-a99501972caa.png">

(Note also that we may have to remove `continuous-integration/codeship` as a required status check, but i don't have the bits to verify/edit)