### PR TITLE
[CARE-4418] Downgrade aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/jay-z",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Youve got 99 problems, but application-layer encryption aint one",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,7 +9,7 @@
     "./src"
   ],
   "dependencies": {
-    "@aws-sdk/client-kms": "^3.40.0",
+    "aws-sdk": "^2.853.0",
     "fast-json-stable-stringify": "^2.1.0",
     "js-yaml": "^3.13.1",
     "libsodium-wrappers": "^0.7.6"

--- a/src/main/KMSDataKeyProvider.ts
+++ b/src/main/KMSDataKeyProvider.ts
@@ -1,17 +1,18 @@
-import { DecryptCommand, GenerateDataKeyCommand, KMSClient } from "@aws-sdk/client-kms"
+import { KMS } from "aws-sdk"
 import { crypto_kdf_KEYBYTES } from "libsodium-wrappers"
 import { DataKey, DataKeyProvider } from "./DataKeyProvider"
 
 /** A KeyProvider that uses an AWS KMS CMK to generate data keys */
 export class KMSDataKeyProvider implements DataKeyProvider {
-  constructor(private keyId: string, private kms: KMSClient = new KMSClient({})) {}
+  constructor(private keyId: string, private kms: KMS = new KMS({})) {}
 
   async generateDataKey(): Promise<DataKey> {
-    const command = new GenerateDataKeyCommand({
-      KeyId: this.keyId,
-      NumberOfBytes: crypto_kdf_KEYBYTES
-    })
-    const result = await this.kms.send(command)
+    const result = await this.kms
+      .generateDataKey({
+        KeyId: this.keyId,
+        NumberOfBytes: crypto_kdf_KEYBYTES
+      })
+      .promise()
 
     const dataKey = result.Plaintext as Uint8Array
     const encryptedDataKey = result.CiphertextBlob as Uint8Array
@@ -23,11 +24,12 @@ export class KMSDataKeyProvider implements DataKeyProvider {
   }
 
   async decryptDataKey(encryptedDataKey: Uint8Array): Promise<Uint8Array> {
-    const command = new DecryptCommand({
-      KeyId: this.keyId,
-      CiphertextBlob: encryptedDataKey
-    })
-    const result = await this.kms.send(command)
+    const result = await this.kms
+      .decrypt({
+        KeyId: this.keyId,
+        CiphertextBlob: encryptedDataKey
+      })
+      .promise()
 
     return result.Plaintext as Uint8Array
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,701 +5,6 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@aws-crypto/ie11-detection@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/ie11-detection@npm:2.0.0"
-  dependencies:
-    tslib: ^1.11.1
-  checksum: dd15daa1160ecdf28b9c930dcbd7f8bc96e74d7f791134974b672f5d36182274c76db4fff414385cdb8997a8b7ade991988a571aaac3184e226e2ed6428d895f
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/sha256-browser@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/sha256-browser@npm:2.0.0"
-  dependencies:
-    "@aws-crypto/ie11-detection": ^2.0.0
-    "@aws-crypto/sha256-js": ^2.0.0
-    "@aws-crypto/supports-web-crypto": ^2.0.0
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    "@aws-sdk/util-locate-window": ^3.0.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: 7bc1ff042d0c53a46c0fc3824bd97fb3ed1df7dc030b8a995889471052860b8c8ade469c97866fafd8249a3144d0f48b0f1054f357e2b403606009381c4b8f0e
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/sha256-js@npm:2.0.0, @aws-crypto/sha256-js@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/sha256-js@npm:2.0.0"
-  dependencies:
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    tslib: ^1.11.1
-  checksum: e4abf9baec6bed19d380f92a999a41ac5bdd8890dfd45971d29054c298854c5b7087e7de633413f2e64618ef8238ccf4c0b75797c73063c74bbba3cb5d8b2581
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/supports-web-crypto@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/supports-web-crypto@npm:2.0.0"
-  dependencies:
-    tslib: ^1.11.1
-  checksum: 77fad3813a5d3c495296fb836293184d32aeddacd436bf7d1b59b93d87de4cf7c0dbf862d4eaf915259edfb7b424ea05e2ceeddbaa1588a154d0c19df455c475
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/util@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/util@npm:2.0.0"
-  dependencies:
-    "@aws-sdk/types": ^3.1.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: afff771bf8023218df3b224f0ad6b8f1a4cded4bdc0a4f9ff7234e7089311034b2046f8ba29d2e94810a46d5c38a2103d4828b60325cb0c49aea4d6cbb741c6a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/abort-controller@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/abort-controller@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: bdfe98a1ddc7bd59a4c7264fe06f718ef348ee636bb74c3b8b3bd3bb2a9118f5d6a26c503aacdf555e741f6ec2c8abc2198351d7c0d7b0fae4aab042a7859393
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-kms@npm:^3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/client-kms@npm:3.40.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/client-sts": 3.40.0
-    "@aws-sdk/config-resolver": 3.40.0
-    "@aws-sdk/credential-provider-node": 3.40.0
-    "@aws-sdk/fetch-http-handler": 3.40.0
-    "@aws-sdk/hash-node": 3.40.0
-    "@aws-sdk/invalid-dependency": 3.40.0
-    "@aws-sdk/middleware-content-length": 3.40.0
-    "@aws-sdk/middleware-host-header": 3.40.0
-    "@aws-sdk/middleware-logger": 3.40.0
-    "@aws-sdk/middleware-retry": 3.40.0
-    "@aws-sdk/middleware-serde": 3.40.0
-    "@aws-sdk/middleware-signing": 3.40.0
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/middleware-user-agent": 3.40.0
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/node-http-handler": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/smithy-client": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    "@aws-sdk/util-base64-node": 3.37.0
-    "@aws-sdk/util-body-length-browser": 3.37.0
-    "@aws-sdk/util-body-length-node": 3.37.0
-    "@aws-sdk/util-user-agent-browser": 3.40.0
-    "@aws-sdk/util-user-agent-node": 3.40.0
-    "@aws-sdk/util-utf8-browser": 3.37.0
-    "@aws-sdk/util-utf8-node": 3.37.0
-    tslib: ^2.3.0
-  checksum: 9740ae9b79d8c0999fe7b837709537f917a15b9cc9a9138694c841b3a5648ea9a1b67581a729526381e189fe5961d31a20baeb10c24811bcde844041bc9dd092
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sso@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/client-sso@npm:3.40.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.40.0
-    "@aws-sdk/fetch-http-handler": 3.40.0
-    "@aws-sdk/hash-node": 3.40.0
-    "@aws-sdk/invalid-dependency": 3.40.0
-    "@aws-sdk/middleware-content-length": 3.40.0
-    "@aws-sdk/middleware-host-header": 3.40.0
-    "@aws-sdk/middleware-logger": 3.40.0
-    "@aws-sdk/middleware-retry": 3.40.0
-    "@aws-sdk/middleware-serde": 3.40.0
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/middleware-user-agent": 3.40.0
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/node-http-handler": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/smithy-client": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    "@aws-sdk/util-base64-node": 3.37.0
-    "@aws-sdk/util-body-length-browser": 3.37.0
-    "@aws-sdk/util-body-length-node": 3.37.0
-    "@aws-sdk/util-user-agent-browser": 3.40.0
-    "@aws-sdk/util-user-agent-node": 3.40.0
-    "@aws-sdk/util-utf8-browser": 3.37.0
-    "@aws-sdk/util-utf8-node": 3.37.0
-    tslib: ^2.3.0
-  checksum: 2314c843af0cdb62c8d8af25cb2d4309d35f5b3f8ef2f70ecd9dd7d62f56c121a8c09ce576535038fe7b72f6ed8eb15c8407c6865e1eb302bda59d5b0c424ff9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sts@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/client-sts@npm:3.40.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.40.0
-    "@aws-sdk/credential-provider-node": 3.40.0
-    "@aws-sdk/fetch-http-handler": 3.40.0
-    "@aws-sdk/hash-node": 3.40.0
-    "@aws-sdk/invalid-dependency": 3.40.0
-    "@aws-sdk/middleware-content-length": 3.40.0
-    "@aws-sdk/middleware-host-header": 3.40.0
-    "@aws-sdk/middleware-logger": 3.40.0
-    "@aws-sdk/middleware-retry": 3.40.0
-    "@aws-sdk/middleware-sdk-sts": 3.40.0
-    "@aws-sdk/middleware-serde": 3.40.0
-    "@aws-sdk/middleware-signing": 3.40.0
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/middleware-user-agent": 3.40.0
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/node-http-handler": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/smithy-client": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    "@aws-sdk/util-base64-node": 3.37.0
-    "@aws-sdk/util-body-length-browser": 3.37.0
-    "@aws-sdk/util-body-length-node": 3.37.0
-    "@aws-sdk/util-user-agent-browser": 3.40.0
-    "@aws-sdk/util-user-agent-node": 3.40.0
-    "@aws-sdk/util-utf8-browser": 3.37.0
-    "@aws-sdk/util-utf8-node": 3.37.0
-    entities: 2.2.0
-    fast-xml-parser: 3.19.0
-    tslib: ^2.3.0
-  checksum: e153c43803a7a0a20360de91c204a87ee6e3a7499b9bacc01c23078a343515294b7b60dcae5688f7fe63d61c8d54df248e93d91961ef9952e444343ac82127ad
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/config-resolver@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/config-resolver@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/signature-v4": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-config-provider": 3.40.0
-    tslib: ^2.3.0
-  checksum: 0f8a153e1cceaaaf102627c803aa15dc248a5893fc783190d8ed9ff13b4b2518164fd43cefda4c8d4dc164bb5bbf66bd435b6e1b7d27e01b7d0f7203c9fd0a70
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-env@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 82b667752d0cfaf78c1f40f952a8027e626cc0ed6bbe1686501c76179e99289563c63bbd4809d66c4a3ee5d26ebccb790338f122c81ff22c3c6cc909bcaa1d8b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-imds@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    tslib: ^2.3.0
-  checksum: c6b7ab2437533debc7579f45a397c6ed44d660c071a99e24b965b74464b6ef916a05b9854b32384cbab40005cecc55669e285ad00193289beca2e21dca76f32a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-ini@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.40.0
-    "@aws-sdk/credential-provider-imds": 3.40.0
-    "@aws-sdk/credential-provider-sso": 3.40.0
-    "@aws-sdk/credential-provider-web-identity": 3.40.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 8d7221f6052f26c7c21c8ed704a9de04b6c99eb9a447c7f6d7713e28be04cae6bb296d392ee4c4283f171aa5a4d3c33340e5e5fa5934f625a3ae034f5f53406f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-node@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.40.0
-    "@aws-sdk/credential-provider-imds": 3.40.0
-    "@aws-sdk/credential-provider-ini": 3.40.0
-    "@aws-sdk/credential-provider-process": 3.40.0
-    "@aws-sdk/credential-provider-sso": 3.40.0
-    "@aws-sdk/credential-provider-web-identity": 3.40.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 5cdcaeb3058a0806510e4c176e4a7d64b3a52d369fbf9b2a21e185c7956442fe98e6d34a7b63090c568622effc4c4abbc1c39c1cdd067b88d51f55f7e7e88701
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 7d1c4200c36cce5efa20cd25f70a15701232b3380ff49f2c3821367c95d9edb28c39e88812359877b517901b4328997440002af75abc9fb320b0a1c81f2b90d3
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-sso@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/client-sso": 3.40.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 9d45ff152e772bf53e1ea10cf43e6701b002e1586392cab10a400dce387950e7d3dfd192a392dea4c0b39abd3ac80aa020fd5038322caedfbd8e158d45f1e1a2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-web-identity@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 28a38a166182563089512a7f6e540906f68aa3eb17fab9657a8f285591f14b0f4d42299ad63ffc2241b3a57c918e90ef3ed4303445289732a15a1c8992937f3d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/fetch-http-handler@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/querystring-builder": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    tslib: ^2.3.0
-  checksum: 3b7a9067469bea360705ce6a81e71fc196810352a98afde98a80613717894c3db5aa53d6dc3f7cead42a5a31b4b85007838506ad4749de1667eeb301e5d4902b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-node@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/hash-node@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-buffer-from": 3.37.0
-    tslib: ^2.3.0
-  checksum: 61a1e4d715af1122700697af8b30af38398d65fcb85fb2d81f3b3ab0205e89758b034e01952c53fd23c5396698c1026dab971977234303d473dceaed230004ca
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/invalid-dependency@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 04063f664403695507bc480f132b09d2f907f411b01e7d52a7a01cb39304548a4d13a3d0d596e7063ed23cd8eb5ae32ca50e60cca32443bd8361bac8cd3992b5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/is-array-buffer@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 5042f7629699448447f6c19733be476c937ca8896fc8958849664f3255198ee90b905794bf224d2f77d54c953ff726babcc1eb457a9817eb44171f6dcfbc7a2c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-content-length@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: bf5a485100e8123f45e4771895d0ede5ba37a89b4d47021f21c880089adabc0ffe35f71e74adc7f21c00c0bf7fd7b47c6050c627f617a1e4133c70243cb812c5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-host-header@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: b2b292c60c930835a95ade5df00a2064002e47e51f757536f7a2e32c1535b6e0d754e5082113229eff503d9c2b77c36b1b987705b640ec6e95eafa5dbf4d4eeb
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 18a2eb55eeffb70e82850d679c699d458d423f176c9b9d61b536f81f99d36fc5c59b64665e2f8a6f526f7efdc7262bf7861ea4a6594604724157f58e347ecad2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-retry@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/service-error-classification": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-    uuid: ^8.3.2
-  checksum: b5e676170bb0b6bbd39ac9557ca10cddfacba4154144c68307e138a7c60dc76a08325ac626e5eeecaaf94e6020e1a86e1cc9fdeec9c8a907c7fa8f9c87b2f164
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-sdk-sts@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/middleware-signing": 3.40.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/signature-v4": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: e40b1f774a2774ccc69de5cd8dd26f25dd23f24d615c1e00a8403e4e86c5798f40531db6326d9511aa9fb081a43d3aa9a93a72d3f3f413b7093775e69ab84f84
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-serde@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 107240744c5cc2e57d0c7811657cc917e9da225402c446375f13f13495888c3e1f24526cb6a092c8fa09f9ed3c5fe2b6ff192ba3661416f1db34029276bfca63
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-signing@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/signature-v4": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 8f729a719b4e9d708ad70ddc11f5e3c918bdf946d10b56cb947d8d2516ca53d49014a6da23d16d1edffbfd05ad40b071c9a96f5a5fc4c865bc4f5af85ae623f8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-stack@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.40.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 7edf1ae49c938647aac6f0f35267ec3c40584e0a5d36f1e366b0c5d7d830cfd6b5a91de1047b5a47e8603a7f780b2aba2af0bcf1c8e5c528dea2c0e442c90116
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-user-agent@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: d3333379810042c7497fe53374f2fb6203c0fd83706fc1fffb6da0267445957f559f81df110628968b01de6c9131335142af8e809d0dd060866c7b9531505355
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-config-provider@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: d52bbea34daaa26df431fc6ad28ce6f80a361e1af88fc4b6fbfeda08b5682d28295c43df40c6d1e11d4344f31b12a65539a05618e14e0dbb4f8beee725fb3727
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-http-handler@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/querystring-builder": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 3a349f80fe4c70ca013d95003da111d1fbea8fdff59abb65dfa2e173bd7bbf099237a22de441b0467656ecda8669c23d8ca3bcdb7735a24f421d3088b56e44c9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/property-provider@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/property-provider@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 8f8adb8ed1c06155d18deacf2cfd192f4ceaa6d742c1566e72bd0cb2e348d3e37cdd32b41607317a3651377a82da516382ded1d15361f4d819f3ac9bfdaed523
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/protocol-http@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/protocol-http@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 238f9a26ee28455ce3920c2b59f05869c7728dfd4420d45d93b32575584cc9e08dbe1cb7d04d0bd30747f59bce2ab469212b330185f0919bf6db564ffbfbfefa
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-builder@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-uri-escape": 3.37.0
-    tslib: ^2.3.0
-  checksum: 63a957597e40a6e99cbb0509fb095174897ad2db50fe415d634caa3aed18748eb8e1522a6ff7d737c09bb8ba6c6108a18a1c1096261dc362fccb6028a533ab80
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-parser@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 48887361713108915b4828acc2d5ca2fc4d52dff0d9d84bba610ea71c13bbb8b8f54efd163e73177c29ee618980d43874373ab90ae0b618d86dbd67186c11c21
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/service-error-classification@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.40.0"
-  checksum: 09db448bc49773bebe37128b6cb1adf2dc3d0c1a3daedfb947dd20bd7b7ad79e49dbb0d3e89bba7022a02b6400cb3e10e521c9170318232988fb9b46f31f6335
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: dea398c739c192d7e9b0542faa5b84d1267dde67ff5576bb8b6709ba5de9039dc8afb9e22104bf88b1b9a67526bde5f0911154dfbe380010eecdaea977e0be00
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/signature-v4@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/signature-v4@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-hex-encoding": 3.37.0
-    "@aws-sdk/util-uri-escape": 3.37.0
-    tslib: ^2.3.0
-  checksum: 5e58a0b43bab13aa2d1945a1ddca3b8e26306aa163061e772f06af6272fb7e1289b87f0a243445a11bd9b91004575c8b0b3e636e5b20f9e8675231a25d7de6d7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/smithy-client@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/smithy-client@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 57a391fb3563a56abcf12cb15a286f5854927713adf5fc21fd1aa90cd17162a809575437f239bb172987852d6607caf8af059bc8cada63692f02952995689fb7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/types@npm:3.40.0, @aws-sdk/types@npm:^3.1.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/types@npm:3.40.0"
-  checksum: 4ff073a21c6f3e75520e5100f58effab236cb79704e3e0cfc3c8c9531bd8b331c84e25a9615b64df2854f8ea7901658a16b3dabfe77e3d21bb25b4e685e117f1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/url-parser@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/url-parser@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/querystring-parser": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: e5bbcdb4c94ffd8bf4c195476b4b606e109c83128e47673700b60a50d27d7c056092c5b491ed3f3439959e1532da5b118f8f06abe8772fe406561b31cdac0dcc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64-browser@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-base64-browser@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 2f2cf2dbf364acc817f9168a3638d550328af6e0166fb7e84660c171ddef25e21bd6d14dde627b10049211352ec2927a41bc0d070b743452d05d0bb853a134c6
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64-node@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-base64-node@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.37.0
-    tslib: ^2.3.0
-  checksum: 71fef0687ca365c480031394fecb0d990084234ea2bf0563090941a55617f1924dfb5d87ec60ef399d4c36b608ddf2de2c4a773087f766949f4246ac379410c4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-body-length-browser@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: ad4065aa8af3ce514d57da6096f80f3e5041b1ba7518058ad17cf31879443daaca6bcb35d37b5ee51bd989bc9d11b0c265d026a73e09e93fc45846de34aacb34
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-body-length-node@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-body-length-node@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 8cf5486b39487ccbc63f96391eff0c0382a7b32af3b7c22cdf0aab764690fb85f9f54c000ace03dfe772b1a3f1d285268efb2f803cdbccfc6136ed174e056d02
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-buffer-from@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.37.0
-    tslib: ^2.3.0
-  checksum: c28c73dd7858cfd31689ecbd2cd9ade93cb577917eea2b8694ac14a838c6365217283dc2b716032f5d51ef1e00ff7a267d2e9bfb09aa7b02fb7d248d5fb7663f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-config-provider@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/util-config-provider@npm:3.40.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 8022f9fc1d7a933ae10cc06faeb03fd0c49719cc9b65682d3b41390837f40f1c9af8cefdb57027f3cce6c4412ab22d940de6993c4dfb401b65c8f0c66a000756
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-credentials@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-credentials@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    tslib: ^2.3.0
-  checksum: b5741e0960d541c79e586ca577ddeec1b1b2de914e4704898b185eb7711d54ae671fe38db1b99ba8dc8361a8feb979ff2427ac53f0cb399602eeb4926e2f3819
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-hex-encoding@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 484d8aa36f0880e910dae2361640dbb29dce462df831e0a771e2b0fb7637b2cf67b9b6144d78312668341b5eca7a982b5f1702ecb326f5509bfc2043bcaabbc7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-locate-window@npm:^3.0.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-locate-window@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: d17fd73797d093a0de2e53ed3999562061858f78b88f993a83d8035fdda613c252a2fbab9abaf1d4fb595ae84e1747e17b137f8079fb99568c0c1641c54f5c4f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-uri-escape@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-uri-escape@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 834f1a535ca3678d62f355bb7e32ae2fe41e789a6a5a27150eeb0089e33c20b3e32f3dbf0c5f8faffa792b3e2f95c22f695ce88103b2ea4cfddd7b73d9d426ed
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-browser@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    bowser: ^2.11.0
-    tslib: ^2.3.0
-  checksum: 63c76d60683e52e5c9541f81bb0071458ede956bd2457898b87314dbd3797dffd6eca410c47ae61198788c83da39cc875b566f91a2ee17b8e6b298784716b64b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-node@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: cbbd4f9c3e7f3f3cd92e48a3aabd7514030f484d378bf89f8a27a71dabdb6e3a9441256d764282c54c3d87ff8031f73b23f7944ddddaff782de485b6f371b7eb
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-browser@npm:3.37.0, @aws-sdk/util-utf8-browser@npm:^3.0.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-utf8-browser@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 93e130926af873f998a7d7b0ac0c12f6878705aee939240a85452879cf4133c23d0e4e95a4ead94eee5e3d7f66c590dce2f78fc3f7e38008318e00c2ae0881de
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-node@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-utf8-node@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.37.0
-    tslib: ^2.3.0
-  checksum: 2699f4024c25b0a5595f0b8b8b3972b5e7061cc5a9d482844113cf9c0c55859280fb577dd945def25e794e4a41260de90ec68dfa7a3e61e414e9e02ae20d5268
-  languageName: node
-  linkType: hard
-
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/code-frame@npm:7.8.3"
@@ -967,10 +272,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ginger.io/jay-z@workspace:."
   dependencies:
-    "@aws-sdk/client-kms": ^3.40.0
     "@types/jest": ^25.1.4
     "@types/libsodium-wrappers": ^0.7.7
     "@types/node": ^13.9.1
+    aws-sdk: ^2.853.0
     fast-json-stable-stringify: ^2.1.0
     jest: ^25.1.0
     js-yaml: ^3.13.1
@@ -1608,6 +913,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"available-typed-arrays@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "available-typed-arrays@npm:1.0.7"
+  dependencies:
+    possible-typed-array-names: ^1.0.0
+  checksum: 1aa3ffbfe6578276996de660848b6e95669d9a95ad149e3dd0c0cda77db6ee1dbd9d1dd723b65b6d277b882dd0c4b91a654ae9d3cf9e1254b7e93e4908d78fd3
+  languageName: node
+  linkType: hard
+
+"aws-sdk@npm:^2.853.0":
+  version: 2.1563.0
+  resolution: "aws-sdk@npm:2.1563.0"
+  dependencies:
+    buffer: 4.9.2
+    events: 1.1.1
+    ieee754: 1.1.13
+    jmespath: 0.16.0
+    querystring: 0.2.0
+    sax: 1.2.1
+    url: 0.10.3
+    util: ^0.12.4
+    uuid: 8.0.0
+    xml2js: 0.6.2
+  checksum: df0de488df00890dd220f9888579e5486293bf5c289ba9807cf6bbe24cc1017f385cd52eb66a119e43a39e6c9063d2aa4f6a7a20f0ff448b0410fb40b297d764
+  languageName: node
+  linkType: hard
+
 "aws-sign2@npm:~0.7.0":
   version: 0.7.0
   resolution: "aws-sign2@npm:0.7.0"
@@ -1681,6 +1013,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64-js@npm:^1.0.2":
+  version: 1.5.1
+  resolution: "base64-js@npm:1.5.1"
+  checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
+  languageName: node
+  linkType: hard
+
 "base@npm:^0.11.1":
   version: 0.11.2
   resolution: "base@npm:0.11.2"
@@ -1702,13 +1041,6 @@ __metadata:
   dependencies:
     tweetnacl: ^0.14.3
   checksum: 4edfc9fe7d07019609ccf797a2af28351736e9d012c8402a07120c4453a3b789a15f2ee1530dc49eee8f7eb9379331a8dd4b3766042b9e502f74a68e7f662291
-  languageName: node
-  linkType: hard
-
-"bowser@npm:^2.11.0":
-  version: 2.11.0
-  resolution: "bowser@npm:2.11.0"
-  checksum: 29c3f01f22e703fa6644fc3b684307442df4240b6e10f6cfe1b61c6ca5721073189ca97cdeedb376081148c8518e33b1d818a57f781d70b0b70e1f31fb48814f
   languageName: node
   linkType: hard
 
@@ -1799,6 +1131,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:4.9.2":
+  version: 4.9.2
+  resolution: "buffer@npm:4.9.2"
+  dependencies:
+    base64-js: ^1.0.2
+    ieee754: ^1.1.4
+    isarray: ^1.0.0
+  checksum: 8801bc1ba08539f3be70eee307a8b9db3d40f6afbfd3cf623ab7ef41dffff1d0a31de0addbe1e66e0ca5f7193eeb667bfb1ecad3647f8f1b0750de07c13295c3
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^18.0.0":
   version: 18.0.1
   resolution: "cacache@npm:18.0.1"
@@ -1833,6 +1176,19 @@ __metadata:
     union-value: ^1.0.0
     unset-value: ^1.0.0
   checksum: 9114b8654fe2366eedc390bad0bcf534e2f01b239a888894e2928cb58cdc1e6ea23a73c6f3450dcfd2058aa73a8a981e723cd1e7c670c047bf11afdc65880107
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.2, call-bind@npm:^1.0.5":
+  version: 1.0.7
+  resolution: "call-bind@npm:1.0.7"
+  dependencies:
+    es-define-property: ^1.0.0
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
+    get-intrinsic: ^1.2.4
+    set-function-length: ^1.2.1
+  checksum: 295c0c62b90dd6522e6db3b0ab1ce26bdf9e7404215bda13cfee25b626b5ff1a7761324d58d38b1ef1607fc65aca2d06e44d2e18d0dfc6c14b465b00d8660029
   languageName: node
   linkType: hard
 
@@ -2142,6 +1498,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"define-data-property@npm:^1.1.2":
+  version: 1.1.4
+  resolution: "define-data-property@npm:1.1.4"
+  dependencies:
+    es-define-property: ^1.0.0
+    es-errors: ^1.3.0
+    gopd: ^1.0.1
+  checksum: 8068ee6cab694d409ac25936eb861eea704b7763f7f342adbdfe337fc27c78d7ae0eff2364b2917b58c508d723c7a074326d068eef2e45c4edcd85cf94d0313b
+  languageName: node
+  linkType: hard
+
 "define-properties@npm:^1.1.2, define-properties@npm:^1.1.3":
   version: 1.1.3
   resolution: "define-properties@npm:1.1.3"
@@ -2265,13 +1632,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:2.2.0":
-  version: 2.2.0
-  resolution: "entities@npm:2.2.0"
-  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
-  languageName: node
-  linkType: hard
-
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -2302,6 +1662,22 @@ __metadata:
     string.prototype.trimleft: ^2.1.1
     string.prototype.trimright: ^2.1.1
   checksum: c8b977a9750f35b8406e3f1006d6e07c5154263776200a6082ff21f83aba36ce1407301965fb064f2936eb16212242625a558392ffe684dd6279f61b4778bc78
+  languageName: node
+  linkType: hard
+
+"es-define-property@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-define-property@npm:1.0.0"
+  dependencies:
+    get-intrinsic: ^1.2.4
+  checksum: f66ece0a887b6dca71848fa71f70461357c0e4e7249696f81bad0a1f347eed7b31262af4a29f5d726dc026426f085483b6b90301855e647aa8e21936f07293c6
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: ec1414527a0ccacd7f15f4a3bc66e215f04f595ba23ca75cdae0927af099b5ec865f9f4d33e9d7e86f512f252876ac77d4281a7871531a50678132429b1271b5
   languageName: node
   linkType: hard
 
@@ -2363,6 +1739,13 @@ __metadata:
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
+  languageName: node
+  linkType: hard
+
+"events@npm:1.1.1":
+  version: 1.1.1
+  resolution: "events@npm:1.1.1"
+  checksum: 40431eb005cc4c57861b93d44c2981a49e7feb99df84cf551baed299ceea4444edf7744733f6a6667e942af687359b1f4a87ec1ec4f21d5127dac48a782039b9
   languageName: node
   linkType: hard
 
@@ -2519,15 +1902,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:3.19.0":
-  version: 3.19.0
-  resolution: "fast-xml-parser@npm:3.19.0"
-  bin:
-    xml2js: cli.js
-  checksum: d9da9145f73d90c05ee2746d80c78eca4da0249dea8c81ea8f1a6e1245e62988ed4a040dbd1c7229b1e0bdcbf69d33c882e0ac337d10c7eedb159a4dc9779327
-  languageName: node
-  linkType: hard
-
 "fb-watchman@npm:^2.0.0":
   version: 2.0.1
   resolution: "fb-watchman@npm:2.0.1"
@@ -2565,6 +1939,15 @@ __metadata:
     locate-path: ^5.0.0
     path-exists: ^4.0.0
   checksum: 4c172680e8f8c1f78839486e14a43ef82e9decd0e74145f40707cc42e7420506d5ec92d9a11c22bd2c48fb0c384ea05dd30e10dd152fefeec6f2f75282a8b844
+  languageName: node
+  linkType: hard
+
+"for-each@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "for-each@npm:0.3.3"
+  dependencies:
+    is-callable: ^1.1.3
+  checksum: 6c48ff2bc63362319c65e2edca4a8e1e3483a2fabc72fbe7feaf8c73db94fc7861bd53bc02c8a66a0c1dd709da6b04eec42e0abdd6b40ce47305ae92a25e5d28
   languageName: node
   linkType: hard
 
@@ -2663,6 +2046,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 2b0ff4ce708d99715ad14a6d1f894e2a83242e4a52ccfcefaee5e40050562e5f6dafc1adbb4ce2d4ab47279a45dc736ab91ea5042d843c3c092820dfe032efb1
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.1":
   version: 1.0.0-beta.1
   resolution: "gensync@npm:1.0.0-beta.1"
@@ -2674,6 +2064,19 @@ __metadata:
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: b9769a836d2a98c3ee734a88ba712e62703f1df31b94b784762c433c27a386dd6029ff55c2a920c392e33657d80191edbf18c61487e198844844516f843496b9
+  languageName: node
+  linkType: hard
+
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.3, get-intrinsic@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "get-intrinsic@npm:1.2.4"
+  dependencies:
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
+    has-proto: ^1.0.1
+    has-symbols: ^1.0.3
+    hasown: ^2.0.0
+  checksum: 414e3cdf2c203d1b9d7d33111df746a4512a1aa622770b361dadddf8ed0b5aeb26c560f49ca077e24bfafb0acb55ca908d1f709216ccba33ffc548ec8a79a951
   languageName: node
   linkType: hard
 
@@ -2747,6 +2150,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gopd@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "gopd@npm:1.0.1"
+  dependencies:
+    get-intrinsic: ^1.1.3
+  checksum: a5ccfb8806e0917a94e0b3de2af2ea4979c1da920bc381667c260e00e7cafdbe844e2cb9c5bcfef4e5412e8bf73bab837285bc35c7ba73aaaf0134d4583393a6
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -2792,10 +2204,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-property-descriptors@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "has-property-descriptors@npm:1.0.2"
+  dependencies:
+    es-define-property: ^1.0.0
+  checksum: fcbb246ea2838058be39887935231c6d5788babed499d0e9d0cc5737494c48aba4fe17ba1449e0d0fbbb1e36175442faa37f9c427ae357d6ccb1d895fbcd3de3
+  languageName: node
+  linkType: hard
+
+"has-proto@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "has-proto@npm:1.0.3"
+  checksum: fe7c3d50b33f50f3933a04413ed1f69441d21d2d2944f81036276d30635cad9279f6b43bc8f32036c31ebdfcf6e731150f46c1907ad90c669ffe9b066c3ba5c4
+  languageName: node
+  linkType: hard
+
 "has-symbols@npm:^1.0.0, has-symbols@npm:^1.0.1":
   version: 1.0.1
   resolution: "has-symbols@npm:1.0.1"
   checksum: 4f09be6682f9fc29855ded1101ad2a0f5d559d7d9ed68f7b68be1ea213c23991216d08d6585bf3ff6fded6f526cc506bda528d276f083602b55d232f132cfa27
+  languageName: node
+  linkType: hard
+
+"has-symbols@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "has-symbols@npm:1.0.3"
+  checksum: a054c40c631c0d5741a8285010a0777ea0c068f99ed43e5d6eb12972da223f8af553a455132fdb0801bdcfa0e0f443c0c03a68d8555aa529b3144b446c3f2410
+  languageName: node
+  linkType: hard
+
+"has-tostringtag@npm:^1.0.0, has-tostringtag@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "has-tostringtag@npm:1.0.2"
+  dependencies:
+    has-symbols: ^1.0.3
+  checksum: 999d60bb753ad714356b2c6c87b7fb74f32463b8426e159397da4bde5bca7e598ab1073f4d8d4deafac297f2eb311484cd177af242776bf05f0d11565680468d
   languageName: node
   linkType: hard
 
@@ -2844,6 +2288,15 @@ __metadata:
   dependencies:
     function-bind: ^1.1.1
   checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "hasown@npm:2.0.1"
+  dependencies:
+    function-bind: ^1.1.2
+  checksum: 9081c382a4fe8a62639a8da5c7d3322b203c319147e48783763dd741863d9f2dcaa743574fe2a1283871c445d8ba99ea45d5fff384e5ad27ca9dd7a367d79de0
   languageName: node
   linkType: hard
 
@@ -2926,6 +2379,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ieee754@npm:1.1.13":
+  version: 1.1.13
+  resolution: "ieee754@npm:1.1.13"
+  checksum: 102df1ba662e316e6160f7ce29c7c7fa3e04f2014c288336c5a9ff40bbcc2a27d209fa2a81ebfb33f28b1941021343d30e9ad8ee85a2d61f79f5936c35edc33d
+  languageName: node
+  linkType: hard
+
+"ieee754@npm:^1.1.4":
+  version: 1.2.1
+  resolution: "ieee754@npm:1.2.1"
+  checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
+  languageName: node
+  linkType: hard
+
 "import-local@npm:^3.0.2":
   version: 3.0.2
   resolution: "import-local@npm:3.0.2"
@@ -2962,7 +2429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2":
+"inherits@npm:2, inherits@npm:^2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -3001,10 +2468,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-arguments@npm:^1.0.4":
+  version: 1.1.1
+  resolution: "is-arguments@npm:1.1.1"
+  dependencies:
+    call-bind: ^1.0.2
+    has-tostringtag: ^1.0.0
+  checksum: 7f02700ec2171b691ef3e4d0e3e6c0ba408e8434368504bb593d0d7c891c0dbfda6d19d30808b904a6cb1929bca648c061ba438c39f296c2a8ca083229c49f27
+  languageName: node
+  linkType: hard
+
 "is-buffer@npm:^1.1.5":
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
   checksum: 4a186d995d8bbf9153b4bd9ff9fd04ae75068fe695d29025d25e592d9488911eeece84eefbd8fa41b8ddcc0711058a71d4c466dcf6f1f6e1d83830052d8ca707
+  languageName: node
+  linkType: hard
+
+"is-callable@npm:^1.1.3":
+  version: 1.2.7
+  resolution: "is-callable@npm:1.2.7"
+  checksum: 61fd57d03b0d984e2ed3720fb1c7a897827ea174bd44402878e059542ea8c4aeedee0ea0985998aa5cc2736b2fa6e271c08587addb5b3959ac52cf665173d1ac
   languageName: node
   linkType: hard
 
@@ -3103,6 +2587,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-generator-function@npm:^1.0.7":
+  version: 1.0.10
+  resolution: "is-generator-function@npm:1.0.10"
+  dependencies:
+    has-tostringtag: ^1.0.0
+  checksum: d54644e7dbaccef15ceb1e5d91d680eb5068c9ee9f9eb0a9e04173eb5542c9b51b5ab52c5537f5703e48d5fddfd376817c1ca07a84a407b7115b769d4bdde72b
+  languageName: node
+  linkType: hard
+
 "is-lambda@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
@@ -3167,6 +2660,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-typed-array@npm:^1.1.3":
+  version: 1.1.13
+  resolution: "is-typed-array@npm:1.1.13"
+  dependencies:
+    which-typed-array: ^1.1.14
+  checksum: 150f9ada183a61554c91e1c4290086d2c100b0dff45f60b028519be72a8db964da403c48760723bf5253979b8dffe7b544246e0e5351dcd05c5fdb1dcc1dc0f0
+  languageName: node
+  linkType: hard
+
 "is-typedarray@npm:^1.0.0, is-typedarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
@@ -3188,7 +2690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isarray@npm:1.0.0":
+"isarray@npm:1.0.0, isarray@npm:^1.0.0":
   version: 1.0.0
   resolution: "isarray@npm:1.0.0"
   checksum: f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
@@ -3713,6 +3215,13 @@ __metadata:
   bin:
     jest: ./bin/jest.js
   checksum: c88bc32df722db944d3dfcaf402509d8f716ea2e2d9e137bf00b09e8556b184a8f13fe003d61d43a252e6b968c03f30eb508f00a26ef4c9fd90fb244193ec40e
+  languageName: node
+  linkType: hard
+
+"jmespath@npm:0.16.0":
+  version: 0.16.0
+  resolution: "jmespath@npm:0.16.0"
+  checksum: 2d602493a1e4addfd1350ac8c9d54b1b03ed09e305fd863bab84a4ee1f52868cf939dd1a08c5cdea29ce9ba8f86875ebb458b6ed45dab3e1c3f2694503fb2fd9
   languageName: node
   linkType: hard
 
@@ -4638,6 +4147,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"possible-typed-array-names@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "possible-typed-array-names@npm:1.0.0"
+  checksum: b32d403ece71e042385cc7856385cecf1cd8e144fa74d2f1de40d1e16035dba097bc189715925e79b67bdd1472796ff168d3a90d296356c9c94d272d5b95f3ae
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:~1.1.2":
   version: 1.1.2
   resolution: "prelude-ls@npm:1.1.2"
@@ -4710,6 +4226,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode@npm:1.3.2":
+  version: 1.3.2
+  resolution: "punycode@npm:1.3.2"
+  checksum: b8807fd594b1db33335692d1f03e8beeddde6fda7fbb4a2e32925d88d20a3aa4cd8dcc0c109ccaccbd2ba761c208dfaaada83007087ea8bfb0129c9ef1b99ed6
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
@@ -4721,6 +4244,13 @@ __metadata:
   version: 6.5.2
   resolution: "qs@npm:6.5.2"
   checksum: 24af7b9928ba2141233fba2912876ff100403dba1b08b20c3b490da9ea6c636760445ea2211a079e7dfa882a5cf8f738337b3748c8bdd0f93358fa8881d2db8f
+  languageName: node
+  linkType: hard
+
+"querystring@npm:0.2.0":
+  version: 0.2.0
+  resolution: "querystring@npm:0.2.0"
+  checksum: 8258d6734f19be27e93f601758858c299bdebe71147909e367101ba459b95446fbe5b975bf9beb76390156a592b6f4ac3a68b6087cea165c259705b8b4e56a69
   languageName: node
   linkType: hard
 
@@ -4966,6 +4496,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:1.2.1":
+  version: 1.2.1
+  resolution: "sax@npm:1.2.1"
+  checksum: 8dca7d5e1cd7d612f98ac50bdf0b9f63fbc964b85f0c4e2eb271f8b9b47fd3bf344c4d6a592e69ecf726d1485ca62cd8a52e603bbc332d18a66af25a9a1045ad
+  languageName: node
+  linkType: hard
+
+"sax@npm:>=0.6.0":
+  version: 1.3.0
+  resolution: "sax@npm:1.3.0"
+  checksum: 238ab3a9ba8c8f8aaf1c5ea9120386391f6ee0af52f1a6a40bbb6df78241dd05d782f2359d614ac6aae08c4c4125208b456548a6cf68625aa4fe178486e63ecd
+  languageName: node
+  linkType: hard
+
 "saxes@npm:^3.1.9":
   version: 3.1.11
   resolution: "saxes@npm:3.1.11"
@@ -5008,6 +4552,20 @@ __metadata:
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
+  languageName: node
+  linkType: hard
+
+"set-function-length@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "set-function-length@npm:1.2.1"
+  dependencies:
+    define-data-property: ^1.1.2
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
+    get-intrinsic: ^1.2.3
+    gopd: ^1.0.1
+    has-property-descriptors: ^1.0.1
+  checksum: 23742476d695f2eae86348c069bd164d4f25fa7c26546a46a2b5f370f1f84b98ec64366d2cd17785d5b41bbf16b95855da4b7eb188e7056fe3b0248d61f6afda
   languageName: node
   linkType: hard
 
@@ -5587,20 +5145,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.11.1":
-  version: 1.14.1
-  resolution: "tslib@npm:1.14.1"
-  checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.3.0":
-  version: 2.3.1
-  resolution: "tslib@npm:2.3.1"
-  checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
-  languageName: node
-  linkType: hard
-
 "tunnel-agent@npm:^0.6.0":
   version: 0.6.0
   resolution: "tunnel-agent@npm:0.6.0"
@@ -5725,6 +5269,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"url@npm:0.10.3":
+  version: 0.10.3
+  resolution: "url@npm:0.10.3"
+  dependencies:
+    punycode: 1.3.2
+    querystring: 0.2.0
+  checksum: 7b83ddb106c27bf9bde8629ccbe8d26e9db789c8cda5aa7db72ca2c6f9b8a88a5adf206f3e10db78e6e2d042b327c45db34c7010c1bf0d9908936a17a2b57d05
+  languageName: node
+  linkType: hard
+
 "use@npm:^3.1.0":
   version: 3.1.1
   resolution: "use@npm:3.1.1"
@@ -5744,21 +5298,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"util@npm:^0.12.4":
+  version: 0.12.5
+  resolution: "util@npm:0.12.5"
+  dependencies:
+    inherits: ^2.0.3
+    is-arguments: ^1.0.4
+    is-generator-function: ^1.0.7
+    is-typed-array: ^1.1.3
+    which-typed-array: ^1.1.2
+  checksum: 705e51f0de5b446f4edec10739752ac25856541e0254ea1e7e45e5b9f9b0cb105bc4bd415736a6210edc68245a7f903bf085ffb08dd7deb8a0e847f60538a38a
+  languageName: node
+  linkType: hard
+
+"uuid@npm:8.0.0":
+  version: 8.0.0
+  resolution: "uuid@npm:8.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 56d4e23aa7ac26fa2db6bd1778db34cb8c9f5a10df1770a27167874bf6705fc8f14a4ac414af58a0d96c7653b2bd4848510b29d1c2ef8c91ccb17429c1872b5e
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^3.3.2":
   version: 3.3.2
   resolution: "uuid@npm:3.3.2"
   bin:
     uuid: ./bin/uuid
   checksum: 8793629d2799f500aeea9fcd0aec6c4e9fbcc4d62ed42159ad96be345c3fffac1bbf61a23e18e2782600884fee05e6d4012ce4b70d0037c8e987533ae6a77870
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 
@@ -5851,6 +5418,19 @@ __metadata:
   version: 2.0.0
   resolution: "which-module@npm:2.0.0"
   checksum: 809f7fd3dfcb2cdbe0180b60d68100c88785084f8f9492b0998c051d7a8efe56784492609d3f09ac161635b78ea29219eb1418a98c15ce87d085bce905705c9c
+  languageName: node
+  linkType: hard
+
+"which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.2":
+  version: 1.1.14
+  resolution: "which-typed-array@npm:1.1.14"
+  dependencies:
+    available-typed-arrays: ^1.0.6
+    call-bind: ^1.0.5
+    for-each: ^0.3.3
+    gopd: ^1.0.1
+    has-tostringtag: ^1.0.1
+  checksum: efe30c143c58630dde8ab96f9330e20165bacd77ca843c602b510120a415415573bcdef3ccbc30a0e5aaf20f257360cfe24712aea0008f149ce5bb99834c0c0b
   languageName: node
   linkType: hard
 
@@ -5965,6 +5545,23 @@ __metadata:
   version: 3.0.0
   resolution: "xml-name-validator@npm:3.0.0"
   checksum: b3ac459afed783c285bb98e4960bd1f3ba12754fd4f2320efa0f9181ca28928c53cc75ca660d15d205e81f92304419afe94c531c7cfb3e0649aa6d140d53ecb0
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:0.6.2":
+  version: 0.6.2
+  resolution: "xml2js@npm:0.6.2"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: 458a83806193008edff44562c0bdb982801d61ee7867ae58fd35fab781e69e17f40dfeb8fc05391a4648c9c54012066d3955fe5d993ffbe4dc63399023f32ac2
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
JIRA Ticket: https://headspace.atlassian.net/browse/CARE-4418

Downgrade the version of aws-sdk that was introduced in this PR: https://github.com/HeadspaceMeditation/jay-z/pull/39. 

Beyonce depends on an older version of aws-sdk, and we need to upgrade Beyonce's version of JayZ to address a security issue. In order to quickly fix the security issue, we are temporarily downgrading aws-sdk.